### PR TITLE
Offer an solution for the 1.3.x version

### DIFF
--- a/chapter4/checkbox-example.html
+++ b/chapter4/checkbox-example.html
@@ -8,6 +8,13 @@
       <label ng-bind="sport.label"></label>
       <div>
         With Binding:
+        <!--In AngularJS 1.3.x, the ng-true-value or ng-false-value will only accept constant expressions.-->
+        <!--Which means the value of ng-true-value should be "'YES'" and the value of ng-false-value should be "'NO'". -->
+        <!--Do notice the single quotes wraped the value -->
+        <!--<input type="checkbox"-->
+               <!--ng-model="sport.selected"-->
+               <!--ng-true-value="'YES'"-->
+               <!--ng-false-value="'NO'">-->
         <input type="checkbox"
                ng-model="sport.selected"
                ng-true-value="YES"


### PR DESCRIPTION
People who use angular.js 1.3.x cannot run this code directly because the ng-true-value of 1.3.x must be a constant string. And there need a single quote to wrap the value we want to use like 'YES' and 'NO' in this case
